### PR TITLE
Add Custom Metric Unix Capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,11 @@ Metrics will be published to the defined path (i.e., http://localhost:3000/metri
       "unicorns.unix.active": {
         "type": "gauge",
         "value": 0
-      }
+      },
+      "unicorn.unix.capacity": {
+        "type": "gauge",
+        "value": 0,
+      },
     }
 ```
 

--- a/lib/unicorn_metrics/middleware.rb
+++ b/lib/unicorn_metrics/middleware.rb
@@ -11,6 +11,7 @@ class UnicornMetrics::Middleware < Raindrops::Middleware
   def initialize(app, opts = {})
     @registry     = UnicornMetrics::Registry
     @metrics_path = opts[:metrics] || "/metrics"
+    @capacity = opts[:capacity] || 0
     super
   end
 
@@ -89,7 +90,8 @@ class UnicornMetrics::Middleware < Raindrops::Middleware
   def raindrops_unix_listener_stats
     hash = {
       "unicorns.unix.active" => { type: :gauge, value: 0 },
-      "unicorns.unix.queued" => { type: :gauge, value: 0 }
+      "unicorns.unix.queued" => { type: :gauge, value: 0 },
+      "unicorn.unix.capacity" => {type: :gauge, value: @capacity }
     }
     Raindrops::Linux.unix_listener_stats(@unix).each do |_, stats|
       hash["unicorns.unix.active"][:value] += stats.active.to_i


### PR DESCRIPTION
Adds the total number of unicorn worker processes as a custom unix
metric.