### PR TITLE
Update name of capacity metric

### DIFF
--- a/lib/unicorn_metrics/middleware.rb
+++ b/lib/unicorn_metrics/middleware.rb
@@ -91,7 +91,7 @@ class UnicornMetrics::Middleware < Raindrops::Middleware
     hash = {
       "unicorns.unix.active" => { type: :gauge, value: 0 },
       "unicorns.unix.queued" => { type: :gauge, value: 0 },
-      "unicorn.unix.capacity" => {type: :gauge, value: @capacity }
+      "unicorns.unix.capacity" => {type: :gauge, value: @capacity }
     }
     Raindrops::Linux.unix_listener_stats(@unix).each do |_, stats|
       hash["unicorns.unix.active"][:value] += stats.active.to_i


### PR DESCRIPTION
Original capacity was misnamed unicorn.metric.capacity, this updates to
include the 's'

Finished in 0.060137s, 764.9201 runs/s, 981.0932 assertions/s.

46 runs, 59 assertions, 0 failures, 0 errors, 0 skips